### PR TITLE
Corrected matrix name in multiplication at model.py

### DIFF
--- a/vision_benchmark/evaluation/model.py
+++ b/vision_benchmark/evaluation/model.py
@@ -577,7 +577,7 @@ class MultiheadAttention(nn.Module):
         elif matrix == 'v':
             if self.factorized_phm_rule:
                 phm_rule2 = torch.bmm(self.phm_rule2_left, self.phm_rule2_right)
-            H = kronecker_product_einsum_batched(phm_rule2, Wq).sum(0)
+            H = kronecker_product_einsum_batched(phm_rule2, Wv).sum(0)
         
         H = self.kdropout(H)
 


### PR DESCRIPTION
There was a mistake in line 580:
`H = kronecker_product_einsum_batched(phm_rule2, Wq).sum(0)`  where Wv is written as Wq. Here phm_rule2 should be multiplied with Wq instead of Wv.